### PR TITLE
Update slack-edge dependency to version 1.3.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slack-cloudflare-workers",
-  "version": "1.3.2",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slack-cloudflare-workers",
-      "version": "1.3.2",
+      "version": "1.3.8",
       "license": "MIT",
       "dependencies": {
         "@cloudflare/workers-types": "^4.20250204.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@cloudflare/workers-types": "^4.20250204.0",
-        "slack-edge": "^1.3.7"
+        "slack-edge": "^1.3.8"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -188,9 +188,9 @@
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/slack-edge": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/slack-edge/-/slack-edge-1.3.7.tgz",
-      "integrity": "sha512-BI+V8WTlaMQmUkBmyJoJ8PDykf6GoJQiCeExkfJ1H6l8Za4Wuv0sM+oV4sOjLgS06+AvOKvya9FgBpcuAKGoAA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/slack-edge/-/slack-edge-1.3.8.tgz",
+      "integrity": "sha512-kNSwiDcgh5WVbNir9SOzsdlXQnFacDk56tuE7k/9uhBacE7GdVqEss3d4DbC89cvppbjP3psttg37EERH3GCPw==",
       "license": "MIT",
       "dependencies": {
         "slack-web-api-client": "^1.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-cloudflare-workers",
-  "version": "1.3.2",
+  "version": "1.3.8",
   "description": "Slack app development framework for Cloudflare Workers",
   "main": "dist/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/slack-edge/slack-cloudflare-workers#readme",
   "dependencies": {
     "@cloudflare/workers-types": "^4.20250204.0",
-    "slack-edge": "^1.3.7"
+    "slack-edge": "^1.3.8"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
Created using Github's new Copilot updater beta

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zhawtof/slack-cloudflare-workers/pull/1?shareId=51b589cc-391f-4f79-9b81-34e1391c87c6).